### PR TITLE
Reconcile library version from Git with CI

### DIFF
--- a/.github/workflows/common_merge.yaml
+++ b/.github/workflows/common_merge.yaml
@@ -65,6 +65,12 @@ jobs:
         password: ${{ secrets.CONTAINER_REPO_TOKEN }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set ownership
+        run: |
+          # Fix for git not liking owner of the checkout dir
+          chown -R $(id -u):$(id -g) $PWD
       # These next two steps will configure CMake if required
       - name: Configure Only Docs
         if: |

--- a/.github/workflows/common_pull_request.yaml
+++ b/.github/workflows/common_pull_request.yaml
@@ -114,6 +114,12 @@ jobs:
         compiler: ${{ fromJSON(inputs.compilers) }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set ownership
+        run: |
+          # Fix for git not liking owner of the checkout dir
+          chown -R $(id -u):$(id -g) $PWD
       - name: Append Repo Settings to CMake Toolchain
         if: inputs.repo_toolchain != ''
         run:  |
@@ -152,6 +158,12 @@ jobs:
         password: ${{ secrets.CONTAINER_REPO_TOKEN }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set ownership
+        run: |
+          # Fix for git not liking owner of the checkout dir
+          chown -R $(id -u):$(id -g) $PWD
       - name: Doxygen Docs
         if: ${{ inputs.doc_target != 'Sphinx' }}
         run:  |


### PR DESCRIPTION
**PR Type**

- [ ] Breaking change
- [ ] Feature
- [x] Patch

**Brief Description**
When trying to get the library version from the git tags, git in the CI container has an issue with the ownership of the checked-out repo. The steps added by this PR change the owner of the checked-out files to the current user in the container.

**Not In Scope**

**PR Checklist**

- [ ] [Is documented](https://nwchemex.github.io/.github/documenting/index.html)
- [ ] [Is tested](https://nwchemex.github.io/.github/testing/index.html)
- [ ] [Adheres to applicable organization standards](https://nwchemex.github.io/.github/conventions/index.html)
