### PR TITLE
Workflow Job Rename

### DIFF
--- a/.github/workflows/common_merge.yaml
+++ b/.github/workflows/common_merge.yaml
@@ -48,7 +48,7 @@ on:
 
 jobs:
   # Bump the version tag
-  bump_tag:
+  increment_tag:
     if: inputs.bump_tag == true
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
**Description**
Changes the `bump_tag` job name in the `common_merge.yaml` workflow to `increment_tag`. This avoids potential confusion with the new input `bump_tag`, and provides a chance to make sure that merging is working correctly in this repo.