### PR TITLE
License Configuration Check

### DIFF
--- a/.github/workflows/common_pull_request.yaml
+++ b/.github/workflows/common_pull_request.yaml
@@ -87,6 +87,14 @@ jobs:
         if: inputs.format_python == true
         with:
           python-version: '3.x'
+      - name: Check License Config
+        if: |
+          inputs.config_file != '' &&
+          hashFiles(inputs.config_file) == ''
+        uses: actions/github-script@v3
+        with:
+          script: |
+            core.setFailed("License Config file doesn't exist: ${{inputs.config_file}}")
       - name: Add license
         if: inputs.config_file != ''
         uses: apache/skywalking-eyes@v0.4.0

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -24,7 +24,7 @@ jobs:
   Common-Pull-Request:
     uses: ./.github/workflows/common_pull_request.yaml
     with:
-      config_file: 'nonexistent.yaml'
+      config_file: ''
       source_dir: ''
       compilers: ''
       doc_target: 'Sphinx'

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -24,7 +24,7 @@ jobs:
   Common-Pull-Request:
     uses: ./.github/workflows/common_pull_request.yaml
     with:
-      config_file: ''
+      config_file: 'nonexistent.yaml'
       source_dir: ''
       compilers: ''
       doc_target: 'Sphinx'


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
Closes #137 

**Description**
Adds a check to the `license_and_format` job in the common PR workflow that will fail if the `config_file` is set to a file name and that file doesn't exist.