### PR TITLE
Clang Toolchain Uses libc++

### DIFF
--- a/nwx_build_environment/toolchains/clang-14.cmake
+++ b/nwx_build_environment/toolchains/clang-14.cmake
@@ -1,2 +1,5 @@
 set(CMAKE_C_COMPILER clang-14)
 set(CMAKE_CXX_COMPILER clang++-14)
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -stdlib=libc++ -lc++abi")


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
No.

**Description**
Update the clang toolchain to use libc++ in CI builds.