### PR TITLE
Add TAMM to build environment

### DIFF
--- a/.github/workflows/common_pull_request.yaml
+++ b/.github/workflows/common_pull_request.yaml
@@ -55,6 +55,11 @@ on:
         type: boolean
         required: false
         default: true
+      build_fail_on_warning:
+        description: "Whether warnings in the library build should be failures"
+        type: boolean
+        required: false
+        default: true
       format_python:
         description: "Whether or not to format python files"
         type: boolean
@@ -148,9 +153,14 @@ jobs:
         run: |
           # Fix for git not liking owner of the checkout dir
           chown -R $(id -u):$(id -g) $PWD
+      - name: Make warnings into errors
+        if: inputs.build_fail_on_warning == true
+        run: |
+          toolchain=/toolchains/nwx_${{ matrix.compiler }}.cmake
+          echo 'include(/toolchains/error_flag.cmake)' >> $toolchain
       - name: Append Repo Settings to CMake Toolchain
         if: inputs.repo_toolchain != ''
-        run:  |
+        run: |
           toolchain=/toolchains/nwx_${{ matrix.compiler }}.cmake
           echo 'include('${PWD}'/${{ inputs.repo_toolchain }})' >> $toolchain
         shell: bash

--- a/.github/workflows/common_pull_request.yaml
+++ b/.github/workflows/common_pull_request.yaml
@@ -142,6 +142,7 @@ jobs:
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.CONTAINER_REPO_TOKEN }}
+    continue-on-error: true
     strategy:
       matrix:
         compiler: ${{ fromJSON(inputs.compilers) }}

--- a/nwx_build_environment/add_catch2.dockerfile
+++ b/nwx_build_environment/add_catch2.dockerfile
@@ -1,7 +1,7 @@
 FROM nwx_buildenv:latest
 
 ARG VERSION=2.13.8
-ARG COMPILER=gcc-9
+ARG COMPILER=gcc-11
 
 # Install catch2 ##
 RUN cd /tmp \

--- a/nwx_build_environment/add_cereal.dockerfile
+++ b/nwx_build_environment/add_cereal.dockerfile
@@ -1,7 +1,7 @@
 FROM nwx_buildenv:latest
 
 ARG VERSION=1.3.0
-ARG COMPILER=gcc-9
+ARG COMPILER=gcc-11
 
 # Install cereal
 RUN cd /tmp \

--- a/nwx_build_environment/add_gauxc.dockerfile
+++ b/nwx_build_environment/add_gauxc.dockerfile
@@ -1,7 +1,7 @@
 FROM nwx_buildenv:latest
 
 ARG VERSION=master
-ARG COMPILER=gcc-9
+ARG COMPILER=gcc-11
 
 # Install libfort ##
 RUN cd /tmp \

--- a/nwx_build_environment/add_libfort.dockerfile
+++ b/nwx_build_environment/add_libfort.dockerfile
@@ -1,7 +1,7 @@
 FROM nwx_buildenv:latest
 
 ARG VERSION=0.4.2
-ARG COMPILER=gcc-9
+ARG COMPILER=gcc-11
 
 # Install libfort ##
 RUN cd /tmp \

--- a/nwx_build_environment/add_madness.dockerfile
+++ b/nwx_build_environment/add_madness.dockerfile
@@ -1,7 +1,7 @@
 FROM nwx_buildenv:latest
 
 ARG VERSION=3d585293f0094588778dbd3bec24b65e7bbe6a5d
-ARG COMPILER=gcc-9
+ARG COMPILER=gcc-11
 
 # Install MADNESS
 RUN cd /tmp \

--- a/nwx_build_environment/add_spdlog.dockerfile
+++ b/nwx_build_environment/add_spdlog.dockerfile
@@ -1,7 +1,7 @@
 FROM nwx_buildenv:latest
 
 ARG VERSION=ad0e89cbfb4d0c1ce4d097e134eb7be67baebb36
-ARG COMPILER=gcc-9
+ARG COMPILER=gcc-11
 
 # Install spdlog
 RUN cd /tmp \

--- a/nwx_build_environment/add_tamm.dockerfile
+++ b/nwx_build_environment/add_tamm.dockerfile
@@ -1,6 +1,6 @@
 FROM nwx_buildenv:latest
 
-ARG VERSION=7c6657610640c5d0f0aa2128da0eef4873f72738
+ARG VERSION=c9ac8eba1bbb237206f620d7464be7725d1809eb
 
 # Install tamm (add dependencies)
 RUN cd /tmp \

--- a/nwx_build_environment/add_tamm.dockerfile
+++ b/nwx_build_environment/add_tamm.dockerfile
@@ -1,6 +1,6 @@
 FROM nwx_buildenv:latest
 
-ARG VERSION=c9ac8eba1bbb237206f620d7464be7725d1809eb
+ARG VERSION=16623d6722ae521edec0b36b460cc25161e42721
 
 # Install tamm (add dependencies)
 RUN cd /tmp \

--- a/nwx_build_environment/add_tamm.dockerfile
+++ b/nwx_build_environment/add_tamm.dockerfile
@@ -1,0 +1,11 @@
+FROM nwx_buildenv:latest
+
+ARG VERSION=7c6657610640c5d0f0aa2128da0eef4873f72738
+
+# Install tamm (add dependencies)
+RUN cd /tmp \
+    && git clone https://github.com/NWChemEx/TAMM.git \
+    && cd TAMM \
+    && git checkout ${VERSION} \
+    && bash /scripts/tamm_command.sh \
+    && rm -rf /tmp/TAMM

--- a/nwx_build_environment/add_tiledarray.dockerfile
+++ b/nwx_build_environment/add_tiledarray.dockerfile
@@ -1,7 +1,7 @@
 FROM nwx_buildenv:latest
 
 ARG VERSION=63e180bf55849c173585a734c5e7456cbf31a986
-ARG COMPILER=gcc-9
+ARG COMPILER=gcc-11
 
 # Install TiledArray
 RUN cd /tmp \

--- a/nwx_build_environment/buildenv.sh
+++ b/nwx_build_environment/buildenv.sh
@@ -1,8 +1,5 @@
 docker build -t nwx_buildenv -f nwx_buildenv.dockerfile .
 
-# TAMM is a special case for now
-docker build -t nwx_buildenv -f add_tamm.dockerfile .
-
 # Build dependencies with both GCC and Clang
 deps=("cereal" "gauxc" "libfort" "catch2" "spdlog")
 for dep in "${deps[@]}"
@@ -11,3 +8,6 @@ do
     docker build -t nwx_buildenv -f add_${dep}.dockerfile --build-arg COMPILER=clang-14 .
     docker image prune -f
 done
+
+# TAMM is a special case for now
+docker build -t nwx_buildenv -f add_tamm.dockerfile .

--- a/nwx_build_environment/buildenv.sh
+++ b/nwx_build_environment/buildenv.sh
@@ -11,3 +11,4 @@ done
 
 # TAMM is a special case for now
 docker build -t nwx_buildenv -f add_tamm.dockerfile .
+docker image prune -f

--- a/nwx_build_environment/buildenv.sh
+++ b/nwx_build_environment/buildenv.sh
@@ -1,5 +1,9 @@
 docker build -t nwx_buildenv -f nwx_buildenv.dockerfile .
 
+# TAMM is a special case for now
+docker build -t nwx_buildenv -f add_tamm.dockerfile .
+
+# Build dependencies with both GCC and Clang
 deps=("cereal" "gauxc" "libfort" "catch2" "spdlog")
 for dep in "${deps[@]}"
 do

--- a/nwx_build_environment/nwx_buildenv.dockerfile
+++ b/nwx_build_environment/nwx_buildenv.dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update \
     libboost-all-dev \
     libopenblas-base libopenblas-dev \
     libscalapack-openmpi-dev \
-    libint2-dev \
+    # libint2-dev \
     libxml2-dev \
     libxslt-dev \
     nwchem \

--- a/nwx_build_environment/scripts/tamm_command.sh
+++ b/nwx_build_environment/scripts/tamm_command.sh
@@ -1,1 +1,2 @@
 CC=gcc CXX=g++ FC=gfortran cmake -Bbuild -H. -DCMAKE_INSTALL_PREFIX=/nwx_dependencies/gcc-11 -DCMAKE_BUILD_TYPE=Release -DBLAS_INT4=ON -DMODULES="CC;DFT"
+cmake --build build --target install --parallel

--- a/nwx_build_environment/scripts/tamm_command.sh
+++ b/nwx_build_environment/scripts/tamm_command.sh
@@ -1,4 +1,4 @@
-CC=gcc CXX=g++ FC=gfortran cmake -Bbuild -H. -DCMAKE_INSTALL_PREFIX=/nwx_dependencies/gcc-11 -DCMAKE_BUILD_TYPE=Release -DBLAS_INT4=ON -DMODULES="CC;DFT" -DCMAKE_TOOLCHAIN_FILE=/toolchains/tamm.cmake
+CC=gcc CXX=g++ FC=gfortran cmake -Bbuild -H. -DCMAKE_INSTALL_PREFIX=/nwx_dependencies/gcc-11 -DCMAKE_BUILD_TYPE=Release -DBLAS_INT4=ON -DMODULES="CC;DFT" -DCMAKE_TOOLCHAIN_FILE=/toolchains/tamm.cmake -DUSE_LIBNUMA=OFF
 cd build
 make -j2
 make install

--- a/nwx_build_environment/scripts/tamm_command.sh
+++ b/nwx_build_environment/scripts/tamm_command.sh
@@ -1,0 +1,1 @@
+CC=gcc CXX=g++ FC=gfortran cmake -Bbuild -H. -DCMAKE_INSTALL_PREFIX=/nwx_dependencies/gcc-11 -DCMAKE_BUILD_TYPE=Release -DBLAS_INT4=ON -DMODULES="CC;DFT"

--- a/nwx_build_environment/scripts/tamm_command.sh
+++ b/nwx_build_environment/scripts/tamm_command.sh
@@ -1,2 +1,4 @@
 CC=gcc CXX=g++ FC=gfortran cmake -Bbuild -H. -DCMAKE_INSTALL_PREFIX=/nwx_dependencies/gcc-11 -DCMAKE_BUILD_TYPE=Release -DBLAS_INT4=ON -DMODULES="CC;DFT"
-cmake --build build --target install
+cd build
+make -j2
+make install

--- a/nwx_build_environment/scripts/tamm_command.sh
+++ b/nwx_build_environment/scripts/tamm_command.sh
@@ -1,2 +1,2 @@
 CC=gcc CXX=g++ FC=gfortran cmake -Bbuild -H. -DCMAKE_INSTALL_PREFIX=/nwx_dependencies/gcc-11 -DCMAKE_BUILD_TYPE=Release -DBLAS_INT4=ON -DMODULES="CC;DFT"
-cmake --build build --target install --parallel
+cmake --build build --target install

--- a/nwx_build_environment/scripts/tamm_command.sh
+++ b/nwx_build_environment/scripts/tamm_command.sh
@@ -1,4 +1,4 @@
-CC=gcc CXX=g++ FC=gfortran cmake -Bbuild -H. -DCMAKE_INSTALL_PREFIX=/nwx_dependencies/gcc-11 -DCMAKE_BUILD_TYPE=Release -DBLAS_INT4=ON -DMODULES="CC;DFT"
+CC=gcc CXX=g++ FC=gfortran cmake -Bbuild -H. -DCMAKE_INSTALL_PREFIX=/nwx_dependencies/gcc-11 -DCMAKE_BUILD_TYPE=Release -DBLAS_INT4=ON -DMODULES="CC;DFT" -DCMAKE_TOOLCHAIN_FILE=/toolchains/tamm.cmake
 cd build
 make -j2
 make install

--- a/nwx_build_environment/toolchains/error_flag.cmake
+++ b/nwx_build_environment/toolchains/error_flag.cmake
@@ -1,0 +1,1 @@
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")

--- a/nwx_build_environment/toolchains/nwx_base.cmake
+++ b/nwx_build_environment/toolchains/nwx_base.cmake
@@ -8,7 +8,7 @@ set(CMAKE_BUILD_TYPE Debug)
 list(APPEND CMAKE_PREFIX_PATH "/nwx_dependencies/${CMAKE_C_COMPILER}")
 # list(APPEND CMAKE_PREFIX_PATH "/usr/share/cmake/libint2/")
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage -std=c++17")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage -std=c++17 -Wall")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DOMPI_SKIP_MPICXX")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} --coverage")
 set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fprofile-arcs")

--- a/nwx_build_environment/toolchains/nwx_base.cmake
+++ b/nwx_build_environment/toolchains/nwx_base.cmake
@@ -5,10 +5,10 @@ set(BUILD_SHARED_LIBS ON)
 set(CATCH_ENABLE_COVERAGE ON)
 set(CMAKE_BUILD_TYPE Debug)
 
-list(APPEND CMAKE_PREFIX_PATH "/usr/share/cmake/libint2/")
 list(APPEND CMAKE_PREFIX_PATH "/nwx_dependencies/${CMAKE_C_COMPILER}")
+# list(APPEND CMAKE_PREFIX_PATH "/usr/share/cmake/libint2/")
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage -std=c++17 -Wall -Werror")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage -std=c++17")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DOMPI_SKIP_MPICXX")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} --coverage")
 set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fprofile-arcs")

--- a/nwx_build_environment/toolchains/tamm.cmake
+++ b/nwx_build_environment/toolchains/tamm.cmake
@@ -1,0 +1,1 @@
+list(APPEND CMAKE_PREFIX_PATH "/nwx_dependencies/gcc-11")


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
No

**Description**
This PR makes changes necessary for adding TAMM to the pre-built dependencies in the build environment. It also updates some default values in several dockerfiles (compiler versions) and adds `continue-on-error: true` (allows other runs in the compiler matrix to complete if another fails first) to the library build step of the PR workflow.