### PR TITLE
Remove stale standard specification

### DIFF
--- a/nwx_build_environment/toolchains/nwx_base.cmake
+++ b/nwx_build_environment/toolchains/nwx_base.cmake
@@ -20,7 +20,7 @@ set(CMAKE_BUILD_TYPE Debug)
 
 list(APPEND CMAKE_PREFIX_PATH "/nwx_dependencies/${CMAKE_C_COMPILER}")
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage -std=c++17 -Wall")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage -Wall")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DOMPI_SKIP_MPICXX")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} --coverage")
 set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fprofile-arcs")
@@ -34,3 +34,4 @@ set(ScaLAPACK_LIBRARIES  "-L${LIBDIR} -lscalapack-openmpi ${LAPACK_LIBRARIES}")
 set(BUILD_PYBIND11_PYBINDINGS ON)
 set(Python_EXECUTABLE /pyenv/bin/python3)
 set(Python3_EXECUTABLE /pyenv/bin/python3)
+

--- a/nwx_build_environment/toolchains/nwx_base.cmake
+++ b/nwx_build_environment/toolchains/nwx_base.cmake
@@ -34,4 +34,3 @@ set(ScaLAPACK_LIBRARIES  "-L${LIBDIR} -lscalapack-openmpi ${LAPACK_LIBRARIES}")
 set(BUILD_PYBIND11_PYBINDINGS ON)
 set(Python_EXECUTABLE /pyenv/bin/python3)
 set(Python3_EXECUTABLE /pyenv/bin/python3)
-


### PR DESCRIPTION
**Description**
Remove the extraneous C++ standard specification from the build environment CMake toolchain.